### PR TITLE
Update `/` syntax highlighting

### DIFF
--- a/syntaxes/aura.tmLanguage.json
+++ b/syntaxes/aura.tmLanguage.json
@@ -23,7 +23,7 @@
             "name": "keyword.operator.new"
         },
         {
-            "match": "\\/",
+            "match": "(?<!\\w)\\/",
             "name": "keyword.operator.new"
         },
         {


### PR DESCRIPTION
* `/` that appear in numerical equations should still be highlighted as an operator
* However, `/` that appear inside word-based expressions should not be highlighted as an operator
* As an example, `5 / 5` should highlight the `/` as an operator, but `import aura/io` should not